### PR TITLE
client-js: Avoid polluting global namespace by 'exports'

### DIFF
--- a/client-js/src/main/js/dcc/ClientException.js
+++ b/client-js/src/main/js/dcc/ClientException.js
@@ -31,10 +31,9 @@ dcc.ClientException = function(msg, code) {
 };
 dcc.DcClass.inherit(dcc.ClientException, Error);
 
-if (typeof exports === "undefined") {
-  exports = {};
+if (typeof exports !== "undefined") {
+  exports.ClientException = dcc.ClientException;
 }
-exports.ClientException = dcc.ClientException;
 
 ///**
 //* プロパティを初期化する.

--- a/client-js/src/main/js/dcc/DcContext.js
+++ b/client-js/src/main/js/dcc/DcContext.js
@@ -35,10 +35,9 @@ dcc.DcContext = function(url, name, boxSchema, bName) {
   this.initializeProperties(this, url, name, boxSchema, bName);
 };
 
-if (typeof exports === "undefined") {
-  exports = {};
+if (typeof exports !== "undefined") {
+  exports.DcContext = dcc.DcContext;
 }
-exports.DcContext = dcc.DcContext;
 
 ///**
 //* バージョン情報を指定するヘッダ.

--- a/client-js/src/main/js/dcc/http/RestAdapter.js
+++ b/client-js/src/main/js/dcc/http/RestAdapter.js
@@ -30,10 +30,9 @@ dcc.http.RestAdapter = function(as) {
   this.initializeProperties(as);
 };
 
-if (typeof exports === "undefined") {
-  exports = {};
+if (typeof exports !== "undefined") {
+  exports.RestAdapter = dcc.http.RestAdapter;
 }
-exports.RestAdapter = dcc.http.RestAdapter;
 
 ///**
 //* プロパティを初期化する.


### PR DESCRIPTION
When you use RequireJS, if 'exports' object is exposed to the global namespace, some AMD modules which change their behavior by checking whether 'exports' exists in the global namespace, are wrongly treated as CommonJS module.
